### PR TITLE
📦 chore(api): add .puppeteerrc.cjs configuration file to specify cach…

### DIFF
--- a/api/.puppeteerrc.cjs
+++ b/api/.puppeteerrc.cjs
@@ -1,0 +1,9 @@
+const { join } = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  // Changes the cache location for Puppeteer.
+  cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+};


### PR DESCRIPTION
…e directory for Puppeteer

The `.puppeteerrc.cjs` file is added to the `api` directory. This file specifies the cache directory for Puppeteer using the `cacheDirectory` property. The cache directory is set to `.cache/puppeteer` relative to the current directory.