### PR TITLE
feat(dashboard): add dashboard page to display various statistics

### DIFF
--- a/ui/pages/dashboard/index.vue
+++ b/ui/pages/dashboard/index.vue
@@ -1,0 +1,64 @@
+<template>
+  <div style="display: flex; flex-direction: column; align-items: center; text-align: center;">
+    <h1>Dashboard</h1>
+    <div style="text-align: left;">
+      <p>Number of courses: {{ user_course_aggregate.aggregate.count }}</p>
+      <p>Number of users: {{ users_aggregate.aggregate.count }}</p>
+      <p>Number of tezos - users: {{ tezos_aggregate.aggregate.count }}</p>
+      <p>Number of email - users: {{ emails_aggregate.aggregate.count }}</p>
+      <p>Last course bought at: {{ user_course[0].created_at }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { gql } from 'graphql-tag'
+
+export default {
+  apollo: {
+    user_course_aggregate: {
+      query: gql`query {
+        user_course_aggregate {
+          aggregate {
+            count
+          }
+        }
+      }`
+    },
+    users_aggregate: {
+      query: gql`query {
+        users_aggregate {
+          aggregate {
+            count
+          }
+        }
+      }`
+    },
+    user_course: {
+      query: gql`query {
+        user_course(order_by: {created_at: desc}, limit: 1) {
+          created_at
+        }
+      }`
+    },
+    tezos_aggregate: {
+      query: gql`query {
+        tezos_aggregate {
+          aggregate {
+            count
+          }
+        }
+      }`
+    },
+    emails_aggregate: {
+      query: gql`query {
+        emails_aggregate {
+          aggregate {
+            count
+          }
+        }
+      }`
+    }
+  }
+}
+</script>


### PR DESCRIPTION
This commit adds a new file `index.vue` under the `ui/pages/dashboard` directory. The `index.vue` file contains the template and script for the dashboard page. The dashboard page displays various statistics related to the application.

The template includes a heading "Dashboard" and a section with multiple paragraphs displaying the following information:
- Number of courses: {{ user_course_aggregate.aggregate.count }}
- Number of users: {{ users_aggregate.aggregate.count }}
- Number of tezos - users: {{ tezos_aggregate.aggregate.count }}
- Number of email - users: {{ emails_aggregate.aggregate.count }}
- Last course bought at: {{ user_course[0].created_at }}

The script section uses Apollo to fetch the necessary data from the GraphQL server. It includes queries to fetch the aggregate counts for user courses, users, tezos users, and email users. It also includes a query to fetch the most recent course bought by a user.

This dashboard page will provide valuable insights and statistics to the users of the application.