### PR TITLE
Add trigger and function for setting first chapter as last_chapter_id_seen in user_course

### DIFF
--- a/hasura/migrations/academy_db/1723849335811_funtion_to_populate_last_chapter_id_seen_in_user_courses/down.sql
+++ b/hasura/migrations/academy_db/1723849335811_funtion_to_populate_last_chapter_id_seen_in_user_courses/down.sql
@@ -1,0 +1,5 @@
+-- Drop the trigger associated with setting the first chapter as last_chapter_id_seen
+DROP TRIGGER IF EXISTS trigger_set_first_chapter_on_user_course ON user_course;
+
+-- Drop the function that sets the first chapter as last_chapter_id_seen
+DROP FUNCTION IF EXISTS set_first_chapter_on_user_course();

--- a/hasura/migrations/academy_db/1723849335811_funtion_to_populate_last_chapter_id_seen_in_user_courses/up.sql
+++ b/hasura/migrations/academy_db/1723849335811_funtion_to_populate_last_chapter_id_seen_in_user_courses/up.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION set_first_chapter_on_user_course()
+RETURNS TRIGGER AS $$
+DECLARE
+    first_module_id UUID;
+    first_chapter_id UUID;
+BEGIN
+    -- Find the first module of the course (the one without a previous_module_id)
+    SELECT id INTO first_module_id
+    FROM modules
+    WHERE course_id = NEW.course_id AND previous_module_id IS NULL
+    LIMIT 1;
+
+    -- Find the first chapter of the first module (the one without a previous_chapter_id)
+    SELECT id INTO first_chapter_id
+    FROM chapters
+    WHERE module_id = first_module_id AND previous_chapter_id IS NULL
+    LIMIT 1;
+
+    -- Update last_chapter_id_seen with the first chapter's id
+    UPDATE user_course
+    SET last_chapter_id_seen = first_chapter_id
+    WHERE user_id = NEW.user_id AND course_id = NEW.course_id;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_set_first_chapter_on_user_course
+AFTER INSERT ON user_course
+FOR EACH ROW
+EXECUTE FUNCTION set_first_chapter_on_user_course();


### PR DESCRIPTION
This pull request adds a trigger and a function to set the first chapter as the `last_chapter_id_seen` in the `user_course` table. The trigger is fired after an insert on the `user_course` table and calls the function `set_first_chapter_on_user_course()`. The function finds the first module and the first chapter of the course and updates the `last_chapter_id_seen` field in the `user_course` table with the first chapter's id. This ensures that the first chapter is marked as viewed when a user starts a course.