### PR TITLE
Add array relationship for courses_payments in public_courses.yaml

### DIFF
--- a/hasura/metadata/databases/academy_db/tables/public_courses.yaml
+++ b/hasura/metadata/databases/academy_db/tables/public_courses.yaml
@@ -19,6 +19,13 @@ object_relationships:
     using:
       foreign_key_constraint_on: teacher_id
 array_relationships:
+  - name: courses_payments
+    using:
+      foreign_key_constraint_on:
+        column: course_id
+        table:
+          name: payments
+          schema: public
   - name: modules
     using:
       foreign_key_constraint_on:


### PR DESCRIPTION
This pull request adds an array relationship for `courses_payments` in the `public_courses.yaml` file. This relationship is defined using a foreign key constraint on the `course_id` column in the `payments` table in the `public` schema.