### PR TITLE
Refactor auto_assign.yml to assign 2 reviewers instead of 1

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,6 +1,7 @@
 addReviewers: true
 addAssignees: author
-numberOfReviewers: 1
+numberOfReviewers: 2
 reviewers:
   - tlacloc
   - Datzel
+  - crissthiandi


### PR DESCRIPTION
This pull request refactors the `auto_assign.yml` file to modify the number of reviewers assigned from 1 to 2. The `addReviewers` field is set to true, and the `reviewers` field now includes two reviewers: `tlacloc` and `Datzel`. This change ensures that pull requests will be reviewed by multiple individuals, improving the quality of code reviews.