### PR TITLE
Add order_by parameter to chapters query in buyCourse page

### DIFF
--- a/ui/pages/buyCourse/_courseId.vue
+++ b/ui/pages/buyCourse/_courseId.vue
@@ -213,7 +213,7 @@ export default {
             modules (order_by: {created_at: asc}) {
               title
               id
-              chapters {
+              chapters (order_by: {created_at: asc}) {
                 id
                 title
               }


### PR DESCRIPTION
This pull request adds the `order_by` parameter to the chapters query in the buyCourse page. This allows the chapters to be ordered by their creation date in ascending order.