### PR TITLE
Rename columns in emails table

### DIFF
--- a/hasura/migrations/academy_db/1724363489109_enhancements_for_chance_password/down.sql
+++ b/hasura/migrations/academy_db/1724363489109_enhancements_for_chance_password/down.sql
@@ -13,30 +13,11 @@ DROP TRIGGER IF EXISTS trigger_reset_change_password_request ON emails;
 DROP FUNCTION IF EXISTS reset_change_password_request();
 
 ALTER TABLE emails
-ADD COLUMN "isVerified" BOOLEAN DEFAULT false;
+RENAME COLUMN is_verified TO "isVerified";
 
 ALTER TABLE emails
-ADD COLUMN "verificationCode" TEXT null;
+RENAME COLUMN verification_code TO "verificationCode";
 
-UPDATE emails
-SET "isVerified" = (
-  SELECT is_verified
-  FROM emails
-  WHERE emails.id = emails.id
-);
-
-UPDATE emails
-SET "verificationCode" = (
-  SELECT verification_code
-  FROM emails
-  WHERE emails.id = emails.id
-);
-
-ALTER TABLE emails
-DROP COLUMN is_verified;
-
-ALTER TABLE emails
-DROP COLUMN verification_code;
 -- Could not auto-generate a down migration.
 -- Please write an appropriate down migration for the SQL below:
 -- alter table "public"."emails" add column "change_password_request_code" text

--- a/hasura/migrations/academy_db/1724363489109_enhancements_for_chance_password/up.sql
+++ b/hasura/migrations/academy_db/1724363489109_enhancements_for_chance_password/up.sql
@@ -9,30 +9,11 @@ alter table "public"."emails" add column "change_password_request_code" text
  null;
 
 ALTER TABLE emails
-ADD COLUMN is_verified BOOLEAN DEFAULT false;
+RENAME COLUMN "isVerified" TO is_verified;
 
 ALTER TABLE emails
-ADD COLUMN verification_code TEXT null;
+RENAME COLUMN "verificationCode" TO verification_code;
 
-UPDATE emails
-SET is_verified = (
-  SELECT "isVerified"
-  FROM emails
-  WHERE emails.id = emails.id
-);
-
-UPDATE emails
-SET verification_code = (
-  SELECT "verificationCode"
-  FROM emails
-  WHERE emails.id = emails.id
-);
-
-ALTER TABLE emails
-DROP COLUMN "isVerified";
-
-ALTER TABLE emails
-DROP COLUMN "verificationCode";
 CREATE OR REPLACE FUNCTION update_change_password_request()
 RETURNS TRIGGER AS $$
 BEGIN


### PR DESCRIPTION
This pull request renames the columns in the emails table from "isVerified" to "is_verified" and from "verificationCode" to "verification_code". The previous column names were inconsistent with the naming conventions used in the rest of the codebase. This change improves code readability and maintainability.