### PR TITLE
Refactor password recovery form and component names

### DIFF
--- a/ui/components/auth/RecoverPasswordFlow.vue
+++ b/ui/components/auth/RecoverPasswordFlow.vue
@@ -27,7 +27,7 @@ export default {
     passwordChanged () {
       this.showInsertCodeForm = false
       this.showNewPasswordForm = false
-      this.$emit('switchComponent', 'auth-sign-in-form')
+      this.$emit('switchComponent', 'auth-log-in-form')
     }
   }
 }

--- a/ui/components/auth/RecoverPasswordForm.vue
+++ b/ui/components/auth/RecoverPasswordForm.vue
@@ -53,7 +53,7 @@ export default {
       <FormulateInput
         name="newPassword"
         type="password"
-        label="Current password"
+        label="New password"
         placeholder="Enter password"
         validation="required|matches:/[0-9]/|min:8,length"
         :validation-messages="{
@@ -63,7 +63,7 @@ export default {
       <FormulateInput
         name="confirmPassword"
         type="password"
-        label="New password"
+        label="Confirm password"
         placeholder="Enter password"
         validation="required"
         validation-name="Confirmation"


### PR DESCRIPTION
The pull request includes commits that refactor the password recovery form and component names. The label in the RecoverPasswordForm.vue file has been updated to 'Confirm password' for consistency. Additionally, the component name has been changed to 'auth-log-in-form' to maintain naming consistency throughout the codebase.