### PR TITLE
Update Procfile to use 'web' instead of 'worker' for running the API

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -1,1 +1,1 @@
-worker: cd api && ls && es -- npm run start
+web: cd api && ls && npm run start


### PR DESCRIPTION
This pull request updates the Procfile to use 'web' instead of 'worker' for running the API. The previous configuration used 'worker', which was incorrect. The patch modifies the Procfile by replacing 'worker' with 'web' in the command to start the API.