### PR TITLE
Update postinstall-server script to include creating a .cache directory and moving puppeteer cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
     "postinstall": "if [ $CLIENT_ENV ]; then npm run postinstall-client; elif [ $SERVER_ENV ]; then npm run postinstall-server; else echo no environment detected, please set CLIENT_ENV or SERVER_ENV; fi",
     "postinstall-client": "cd ui && NODE_ENV=development yarn && yarn build",
-    "postinstall-server": "cd api && yarn",
+    "postinstall-server": "cd api && yarn && mkdir ./.cache && mv /app/.cache/puppeteer ./.cache",
     "start": "if [ $CLIENT_ENV ]; then npm run start-client; elif [ $SERVER_ENV ]; then npm run start-server; else echo no environment detected, please set CLIENT_ENV or SERVER_ENV; fi",
     "start-client": "NODE_ENV=production cd ui && yarn start",
     "start-server": "NODE_ENV=production cd api && yarn start"


### PR DESCRIPTION
This pull request updates the postinstall-server script in the package.json file. It now includes creating a .cache directory and moving the puppeteer cache to that directory. This change ensures that the puppeteer cache is properly organized and stored in the .cache directory.