### PR TITLE
object-cover class added to display the pfp img properly

### DIFF
--- a/ui/components/layout/PxProfile.vue
+++ b/ui/components/layout/PxProfile.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="tw-relative">
       <div @click.stop="toggleDropdown">
-        <img v-if="$auth.user.pfp && imageLoaded" class="tw-overflow-hidden tw-rounded-full tw-w-[35px] tw-h-[35px] tw-cursor-pointer" :src="$auth.user.pfp" @error="onImageError">
+        <img v-if="$auth.user.pfp && imageLoaded" class="tw-overflow-hidden tw-rounded-full tw-w-[35px] tw-h-[35px] tw-cursor-pointer tw-object-cover" :src="$auth.user.pfp" @error="onImageError">
 
         <div v-else class="tw-rounded-full tw-w-[35px] tw-h-[35px] tw-cursor-pointer tw-border tw-flex tw-items-center tw-justify-center">
           <Icon


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the profile picture display by adding the 'tw-object-cover' class to ensure the image is properly contained and displayed within its circular frame.

Enhancements:
- Add 'tw-object-cover' class to the profile picture image to ensure it displays properly within its container.

<!-- Generated by sourcery-ai[bot]: end summary -->