### PR TITLE
Update ilithya course release date

### DIFF
--- a/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/down.sql
+++ b/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/down.sql
@@ -1,0 +1,3 @@
+UPDATE courses
+SET SET release_date = '2024-09-03T17:00:00.075383+00:00'
+WHERE id = '5f1f6044-21ba-4409-880e-02cd36568697';

--- a/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/down.sql
+++ b/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/down.sql
@@ -1,3 +1,3 @@
 UPDATE courses
-SET SET release_date = '2024-09-03T17:00:00.075383+00:00'
+SET release_date = '2024-09-03T17:00:00.075383+00:00'
 WHERE id = '5f1f6044-21ba-4409-880e-02cd36568697';

--- a/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/up.sql
+++ b/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/up.sql
@@ -1,0 +1,4 @@
+-- update release date
+UPDATE courses
+SET release_date = '2024-09-03T07:00:00.075383+00:00'
+WHERE id = '5f1f6044-21ba-4409-880e-02cd36568697';

--- a/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/up.sql
+++ b/hasura/migrations/academy_db/1725299701125_update_ilithya_release_date/up.sql
@@ -1,4 +1,4 @@
--- update release date
+-- update release date to 2024-09-03 9:00:00 AM CET
 UPDATE courses
 SET release_date = '2024-09-03T07:00:00.075383+00:00'
 WHERE id = '5f1f6044-21ba-4409-880e-02cd36568697';


### PR DESCRIPTION
The code changes in this pull request update the release date of the ilithya course to '2024-09-03T07:00:00.075383+00:00'. This ensures that the course is available for users starting from the specified date.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the release date of the ilithya course in the database to ensure it is available to users starting from September 3, 2024.

Enhancements:
- Update the release date of the ilithya course to '2024-09-03T07:00:00.075383+00:00' in the database.

<!-- Generated by sourcery-ai[bot]: end summary -->