### PR TITLE
Update buyCourse page to include dynamic nowDate

### DIFF
--- a/ui/pages/buyCourse/_courseId.vue
+++ b/ui/pages/buyCourse/_courseId.vue
@@ -280,7 +280,8 @@ export default {
       userCourses: [],
       showFullDescription:
       false,
-      maxLength: 700
+      maxLength: 700,
+      nowDate: new Date()
     }
   },
   computed: {
@@ -289,7 +290,7 @@ export default {
     },
     isReleased: function () {
       const releaseDate = this.courses[0].release_date
-      return !releaseDate || new Date(releaseDate) < new Date()
+      return !releaseDate || new Date(releaseDate) < this.nowDate
     },
     hasEarlyAccess: function () {
       if (!this.$auth.loggedIn) {
@@ -351,8 +352,14 @@ export default {
 
   mounted () {
     this.getUserCourses()
+    setInterval(() => {
+      this.updateNowDate()
+    }, 30000)
   },
   methods: {
+    updateNowDate () {
+      this.nowDate = new Date()
+    },
     toggleDescription () {
       this.showFullDescription = !this.showFullDescription
     },


### PR DESCRIPTION
This pull request updates the buyCourse page to include a dynamic nowDate. The nowDate is set to the current date and time and is used in the isReleased computed property to determine if a course has been released. Additionally, a setInterval function has been added to update the nowDate every 30 seconds.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the buyCourse page to include a dynamic nowDate property that is refreshed every 30 seconds, and use it in the isReleased computed property to determine if a course has been released.

Enhancements:
- Introduce a dynamic nowDate property on the buyCourse page to track the current date and time.

<!-- Generated by sourcery-ai[bot]: end summary -->