### PR TITLE
Changes in payment intents

### DIFF
--- a/api/constants/index.js
+++ b/api/constants/index.js
@@ -1,6 +1,9 @@
 const Role = require('./roles.js')
 const TezosConstants = require('./tezos.js')
+const PaymentConstants = require('./payments.js')
+
 module.exports = {
   Role,
-  TezosConstants
+  TezosConstants,
+  PaymentConstants
 }

--- a/api/constants/payments.js
+++ b/api/constants/payments.js
@@ -1,0 +1,9 @@
+const TRANSACTION_TYPES = {
+  STRIPE: 'stripe',
+  TEZOS: 'tezos',
+  GIFT: 'gift'
+}
+
+module.exports = {
+  TRANSACTION_TYPES
+}

--- a/api/graphQL/payments.js
+++ b/api/graphQL/payments.js
@@ -18,25 +18,6 @@ query ($id: String!) {
 }
 `
 
-const GET_PAYMENT_INTENT_INFO = gql`
-query ($userId: String!, $courseId: String!) {
-  payments(where: {user_id: {_eq: $userId}, course_id: {_eq: $courseId}}) {
-    transaction_info {
-      transactions_stripe_transaction_info {
-        payment_intent
-        payment_intent_client_secret
-        id
-      }
-      transactions_tezos_transaction_info {
-        operation_hash
-        wallet
-        id
-      }
-    }
-  }
-}
-`
-
 const CREATE_PAYMENT_INTENT = gql`
 mutation ($courseId: String!, $userId: String!) {
   insert_payments_one(
@@ -66,77 +47,82 @@ mutation ($courseId: String!, $userId: String!) {
   }
 }
 `
-// TODO: fix this mutation - update instead
-const CREATE_STRIPE_PAYMENT_INTENT = gql`
-mutation (
-  $courseId: String!,
-  $userId: String!,
-  $paymentIntent: String!,
-  $paymentIntentClientSecret: String!,
-  $amount: numeric!,
-  $transactionId: String!
-  ) {
-  insert_payments_one(
-    object: {
-      course_id: $courseId,
-      user_id: $userId,
-      transaction_type: stripe,
-      transaction_info: {
-        data: {transactions_stripe_transaction_info: {
-          data: {
-            payment_intent: $paymentIntent,
-            payment_intent_client_secret: $paymentIntentClientSecret,
-            amount: $amount}
-          },
-          id: $transactionId
-        },
-        on_conflict: {
-          constraint: transactions_pkey,
-          update_columns: stripe_transaction_id
-        }}},
-        on_conflict: {constraint: payments_pkey, update_columns: updated_at}) {
-    transaction_id
+
+const GET_PAYMENT_INTENT_INFO = gql`
+query ($courseId: String!, $userId: String!) {
+  payments_by_pk(course_id: $courseId, user_id: $userId) {
+    course_id
+    user_id
     transaction_info {
       stripe_transaction_id
       tezos_transaction_id
+      transactions_stripe_transaction_info {
+        payment_intent
+        payment_intent_client_secret
+        id
+      }
+      transactions_tezos_transaction_info {
+        operation_hash
+        wallet
+        id
+      }
     }
   }
 }
 `
 // TODO: fix this mutation - update instead
-const CREATE_TEZOS_PAYMENT_INTENT = gql`
+const CREATE_STRIPE_PAYMENT_INTENT = gql`
 mutation (
-  $courseId: String!,
-  $userId: String!,
-  $wallet: String!,
+  $stripeTransactionId: String!,
   $amount: numeric!,
-  $transactionId: String!
+  $paymentIntent: String!,
+  $paymentIntentClientSecret: String!
+) {
+  update_stripe_transaction_info_by_pk(
+    pk_columns: {
+      id: $stripeTransactionId
+    },
+    _set: {
+      amount: $amount,
+      payment_intent: $paymentIntent,
+      payment_intent_client_secret: $paymentIntentClientSecret
+    }
   ) {
-  insert_payments_one(
-    object: {
-      course_id: $courseId,
-      user_id: $userId,
-      transaction_type: tezos,
-      transaction_info: {
-        data: {transactions_tezos_transaction_info: {
-          data: {
-            wallet: $wallet,
-            amount: $amount}
-          },
-          id: $transactionId
-        },
-        on_conflict: {
-          constraint: transactions_pkey,
-          update_columns: tezos_transaction_id
-        }}},
-        on_conflict: {constraint: payments_pkey, update_columns: updated_at}) {
-    transaction_id
     transaction_info {
+      id
       stripe_transaction_id
       tezos_transaction_id
     }
   }
 }
+
+`
+// TODO: fix this mutation - update instead
+const CREATE_TEZOS_PAYMENT_INTENT = gql`
+mutation (
+  $tezosTransactionId: String!,
+  $amount: numeric!,
+  $wallet: String!,
+  $operationHash: String = ""
+) {
+  update_tezos_transaction_info_by_pk(
+    pk_columns: {
+      id: $tezosTransactionId
+    },
+    _set: {
+      amount: $amount,
+      wallet: $wallet,
+      operation_hash: $operationHash
+    }
+  ) {
+    transaction_info {
+      id
+      stripe_transaction_id
+      tezos_transaction_id
+    }
+  }
+}
+
 `
 const ADD_USER_TO_COURSE = gql`
 mutation ($courseId: String!, $userId: String!) {

--- a/api/graphQL/payments.js
+++ b/api/graphQL/payments.js
@@ -70,7 +70,7 @@ query ($courseId: String!, $userId: String!) {
   }
 }
 `
-// TODO: fix this mutation - update instead
+
 const CREATE_STRIPE_PAYMENT_INTENT = gql`
 mutation (
   $stripeTransactionId: String!,
@@ -97,7 +97,7 @@ mutation (
 }
 
 `
-// TODO: fix this mutation - update instead
+
 const CREATE_TEZOS_PAYMENT_INTENT = gql`
 mutation (
   $tezosTransactionId: String!,
@@ -157,6 +157,26 @@ query ($paymentIntent: String!) {
 }
 `
 
+const UPDATE_PAYMENT_INFO = gql`
+mutation (
+  $courseId: String!,
+  $userId: String!,
+  $transactionType: transaction_types_enum!
+) {
+  update_payments_by_pk(
+    pk_columns: {
+      user_id: $userId,
+      course_id: $courseId
+    },
+    _set: {
+      transaction_type: $transactionType
+    }
+  ) {
+    user_id
+    course_id
+  }
+}
+`
 module.exports = {
   GET_COURSE_BY_ID,
   GET_PAYMENT_INTENT_INFO,
@@ -165,5 +185,6 @@ module.exports = {
   CREATE_TEZOS_PAYMENT_INTENT,
   ADD_USER_TO_COURSE,
   GET_USER_COURSE,
-  GET_PAYMENT_INTENT_INFO_FROM_STRIPE_INTENT
+  GET_PAYMENT_INTENT_INFO_FROM_STRIPE_INTENT,
+  UPDATE_PAYMENT_INFO
 }

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
     "jsonwebtoken": "^9.0.1",
     "puppeteer": "^21.3.6",
     "raw-body": "^2.5.2",
-    "stripe": "^13.9.0",
+    "stripe": "^16.9.0",
     "uint8arrays": "^4.0.6",
     "uuid": "^9.0.0"
   },
@@ -60,7 +60,7 @@
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unicorn": "^48.0.1",
-    "pino-pretty": "^10.2.0",
+    "pino-pretty": "^11.2.2",
     "prettier": "^3.0.0",
     "prettier-eslint": "^15.0.1",
     "tap": "^16.1.0"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2477,7 +2477,7 @@ fast-content-type-parse@^1.1.0:
   resolved "https://registry.yarnpkg.com/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz#4087162bf5af3294d4726ff29b334f72e3a1092c"
   integrity sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==
 
-fast-copy@^3.0.0:
+fast-copy@^3.0.0, fast-copy@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
   integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
@@ -4459,7 +4459,7 @@ pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.2.0:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
-pino-pretty@^10.1.0, pino-pretty@^10.2.0:
+pino-pretty@^10.1.0:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.3.1.tgz#e3285a5265211ac6c7cd5988f9e65bf3371a0ca9"
   integrity sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==
@@ -4477,6 +4477,26 @@ pino-pretty@^10.1.0, pino-pretty@^10.2.0:
     readable-stream "^4.0.0"
     secure-json-parse "^2.4.0"
     sonic-boom "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+pino-pretty@^11.2.2:
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.2.2.tgz#5e8ec69b31e90eb187715af07b1d29a544e60d39"
+  integrity sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.2"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^1.0.0"
+    pump "^3.0.0"
+    readable-stream "^4.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^4.0.1"
     strip-json-comments "^3.1.1"
 
 pino-std-serializers@^7.0.0:
@@ -5304,10 +5324,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^13.9.0:
-  version "13.11.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-13.11.0.tgz#f51e1acf1ec75e85a405130e8b28f6dfd68be34b"
-  integrity sha512-yPxVJxUzP1QHhHeFnYjJl48QwDS1+5befcL7ju7+t+i88D5r0rbsL+GkCCS6zgcU+TiV5bF9eMGcKyJfLf8BZQ==
+stripe@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-16.9.0.tgz#235804314bb4b1b804663ea47c66799cc762e9eb"
+  integrity sha512-SgzwdMgWNe1FD1A1WevZ/wuv8b4yWz8SiG/vO7Pf4cBl0qat20Clz8Zself+tcbB+fuMkZJrjJ2WmarIgXfCow==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"

--- a/hasura/migrations/academy_db/1725311973177_insert_into_public_transaction_types/down.sql
+++ b/hasura/migrations/academy_db/1725311973177_insert_into_public_transaction_types/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."transaction_types" WHERE "name" = 'gift';

--- a/hasura/migrations/academy_db/1725311973177_insert_into_public_transaction_types/up.sql
+++ b/hasura/migrations/academy_db/1725311973177_insert_into_public_transaction_types/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."transaction_types"("name") VALUES (E'gift');


### PR DESCRIPTION
This pull request refactors the payment GraphQL queries and mutations in the `payments.js` file. It updates the `GET_PAYMENT_INTENT_INFO` query to use the `payments_by_pk` field instead of the `payments` field. It also updates the `CREATE_PAYMENT_INTENT` mutation to use the `insert_payments_one` field instead of the `insert_payments_one` field. These changes improve the clarity and consistency of the codebase.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor payment GraphQL queries and mutations to improve efficiency and consistency by using primary key-based queries and updates. Introduce transaction type management to handle different payment methods and add a new mutation for updating payment information. Implement a new constant for transaction types and update the database schema to include a 'gift' transaction type.

New Features:
- Introduce a new GraphQL mutation `UPDATE_PAYMENT_INFO` to update payment information with transaction type.

Enhancements:
- Refactor the `GET_PAYMENT_INTENT_INFO` query to use `payments_by_pk` for more efficient data retrieval.
- Refactor the `CREATE_PAYMENT_INTENT` mutation to update existing payment intents instead of inserting new ones.
- Add transaction type handling in the `addCourseToUser` method to support different payment methods.
- Introduce a new constant `TRANSACTION_TYPES` to manage different types of transactions such as 'stripe', 'tezos', and 'gift'.

Chores:
- Add a new SQL migration to insert and delete 'gift' transaction type in the `transaction_types` table.

<!-- Generated by sourcery-ai[bot]: end summary -->