### PR TITLE
fields that do not work yet have been hidden

### DIFF
--- a/ui/pages/profile/index.vue
+++ b/ui/pages/profile/index.vue
@@ -42,6 +42,7 @@
               validation="required"
             />
             <FormulateInput
+              v-if="false"
               :value="$auth.user.email_info ? $auth.user.email_info.email : $auth.user.email_info"
               name="email"
               type="email"
@@ -57,10 +58,11 @@
         </div>
 
         <auth-change-password-form
+          v-if="false"
           :user-id="$auth.user.id"
         />
 
-        <div v-if="!$auth.user.tezos_info">
+        <div v-if="false">
           <hr>
           <div class="d-flex flex-column my-4">
             <p class="m-0">
@@ -77,7 +79,7 @@
           </div>
         </div>
 
-        <div v-else>
+        <div v-if="false">
           <hr>
           <div class="d-flex ">
             <p style="color:#3ed082">


### PR DESCRIPTION
This PR hides some fields of the email form, password change and wallet linking because they are not yet functional

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Hide non-functional fields in the profile page to prevent user interaction with incomplete features.

Enhancements:
- Hide non-functional fields in the profile page, including email form, password change, and wallet linking sections.

<!-- Generated by sourcery-ai[bot]: end summary -->