### PR TITLE
Update teachers' profile pictures URLs

### DIFF
--- a/hasura/migrations/academy_db/1725581237165_remove_pinata_url/down.sql
+++ b/hasura/migrations/academy_db/1725581237165_remove_pinata_url/down.sql
@@ -1,15 +1,15 @@
 
 -- Ilithya
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmV2PBdksQNvsyMfwxcXVvq4Y22BA8rXWSVmTFnMkhB9FG'
 WHERE id = 'b1c88742-d6a4-4556-8e92-83a7e9374dc5';
 
 -- Heeey
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmVcpQcNSNhmYdLuTZzgTxmkMtr7qyNQKRnDpwLCiVTTDL'
 WHERE id = 'f99406ba-af32-4bb3-b300-9eb034149ea5';
 
 -- Blind Gallery
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmQaWUwSojC4rvS3pyq4AU4ocwjwb1q87nNLjHmwUCqoks'
 WHERE id = '6332eb59-d69a-4700-815f-c85f27ac73ce';

--- a/hasura/migrations/academy_db/1725581237165_remove_pinata_url/down.sql
+++ b/hasura/migrations/academy_db/1725581237165_remove_pinata_url/down.sql
@@ -1,0 +1,15 @@
+
+-- Ilithya
+UPDATE teachers_user
+SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmV2PBdksQNvsyMfwxcXVvq4Y22BA8rXWSVmTFnMkhB9FG'
+WHERE id = 'b1c88742-d6a4-4556-8e92-83a7e9374dc5';
+
+-- Heeey
+UPDATE teachers_user
+SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmVcpQcNSNhmYdLuTZzgTxmkMtr7qyNQKRnDpwLCiVTTDL'
+WHERE id = 'f99406ba-af32-4bb3-b300-9eb034149ea5';
+
+-- Blind Gallery
+UPDATE teachers_user
+SET pfp = E'https://moccasin-perfect-trout-941.mypinata.cloud/ipfs/QmQaWUwSojC4rvS3pyq4AU4ocwjwb1q87nNLjHmwUCqoks'
+WHERE id = '6332eb59-d69a-4700-815f-c85f27ac73ce';

--- a/hasura/migrations/academy_db/1725581237165_remove_pinata_url/up.sql
+++ b/hasura/migrations/academy_db/1725581237165_remove_pinata_url/up.sql
@@ -1,0 +1,14 @@
+-- ilithya
+UPDATE teachers_user
+SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmV2PBdksQNvsyMfwxcXVvq4Y22BA8rXWSVmTFnMkhB9FG'
+WHERE id = 'b1c88742-d6a4-4556-8e92-83a7e9374dc5';
+
+-- Heeey
+UPDATE teachers_user
+SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmVcpQcNSNhmYdLuTZzgTxmkMtr7qyNQKRnDpwLCiVTTDL'
+WHERE id = 'f99406ba-af32-4bb3-b300-9eb034149ea5';
+
+-- Blind Gallery
+UPDATE teachers_user
+SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmQaWUwSojC4rvS3pyq4AU4ocwjwb1q87nNLjHmwUCqoks'
+WHERE id = '6332eb59-d69a-4700-815f-c85f27ac73ce';

--- a/hasura/migrations/academy_db/1725581237165_remove_pinata_url/up.sql
+++ b/hasura/migrations/academy_db/1725581237165_remove_pinata_url/up.sql
@@ -1,14 +1,14 @@
 -- ilithya
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmV2PBdksQNvsyMfwxcXVvq4Y22BA8rXWSVmTFnMkhB9FG'
 WHERE id = 'b1c88742-d6a4-4556-8e92-83a7e9374dc5';
 
 -- Heeey
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmVcpQcNSNhmYdLuTZzgTxmkMtr7qyNQKRnDpwLCiVTTDL'
 WHERE id = 'f99406ba-af32-4bb3-b300-9eb034149ea5';
 
 -- Blind Gallery
-UPDATE teachers_user
+UPDATE teachers
 SET pfp = E'https://blind-gallery.infura-ipfs.io/ipfs/QmQaWUwSojC4rvS3pyq4AU4ocwjwb1q87nNLjHmwUCqoks'
 WHERE id = '6332eb59-d69a-4700-815f-c85f27ac73ce';


### PR DESCRIPTION
This pull request updates the profile picture URLs for three teachers. The URLs are changed to use the "blind-gallery.infura-ipfs.io" domain instead of the "moccasin-perfect-trout-941.mypinata.cloud" domain. The changes are made in the "up.sql" and "down.sql" files in the "hasura/migrations/academy_db/1725581237165_remove_pinata_url" directory.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Change the domain for teachers' profile picture URLs in the database migration scripts to 'blind-gallery.infura-ipfs.io'.

Enhancements:
- Update the profile picture URLs for three teachers to use the 'blind-gallery.infura-ipfs.io' domain instead of the 'moccasin-perfect-trout-941.mypinata.cloud' domain.

<!-- Generated by sourcery-ai[bot]: end summary -->