### PR TITLE
feat: Update Tezos RPC endpoints to use new URLs

### DIFF
--- a/api/constants/tezos.js
+++ b/api/constants/tezos.js
@@ -5,7 +5,7 @@ const DEFAULT_CONFIRMATION_BLOCKS = 1
 
 const endpoints = {
   mainnet: 'https://rpc.tzkt.io/mainnet',
-  ghostnet: 'https://rpc.tzkt.io/ghostnet'
+  ghostnet: 'https://rpc.ghostnet.teztnets.com/'
 }
 
 const tzktEndpoints = {

--- a/ui/constants/tezos.js
+++ b/ui/constants/tezos.js
@@ -8,7 +8,7 @@ export const RCP_URI = 'https://mainnet.api.tez.ie'
 
 const endpoints = {
   mainnet: 'https://rpc.tzkt.io/mainnet',
-  ghostnet: 'https://rpc.tzkt.io/ghostnet'
+  ghostnet: 'https://rpc.ghostnet.teztnets.com/'
 }
 
 const tzktEndpoints = {


### PR DESCRIPTION
This commit updates the Tezos RPC endpoints in the codebase to use the new URLs provided. The `mainnet` endpoint is now set to 'https://rpc.tzkt.io/mainnet' and the `ghostnet` endpoint is set to 'https://rpc.ghostnet.teztnets.com/'. This change ensures that the application is using the correct RPC endpoints for Tezos network communication.

[More documentation here](https://taquito.io/docs/rpc_nodes/)