### PR TITLE
Wrap Stripe register in try-catch

### DIFF
--- a/api/model/Login.js
+++ b/api/model/Login.js
@@ -21,15 +21,15 @@ class Login {
   }
 
   async stripeRegister (user, ip) {
-    const { customerId, country } = await this.stripe.registerCustomer({ customerId: user.customer_id, user, ip })
-    logger.debug(`Stripe customer registered: ${customerId}`)
-    if (!user.customer_id || user.country !== country) {
-      try {
+    try {
+      const { customerId, country } = await this.stripe.registerCustomer({ customerId: user.customer_id, user, ip })
+      logger.debug(`Stripe customer registered: ${customerId}`)
+      if (!user.customer_id || user.country !== country) {
         await this.gql.request(
           REGISTER_CUSTOMER_ID, { id: user.id, customerId, country })
-      } catch (e) {
-        logger.error(`Error registering customer: ${e.message}`)
       }
+    } catch (e) {
+      logger.error(`Error registering customer: ${e.message}`)
     }
   }
 

--- a/api/service/Stripe.js
+++ b/api/service/Stripe.js
@@ -20,7 +20,14 @@ async function safeStripeOperation (operation, errorMessage) {
 }
 class Stripe {
   async getIPDetails (ip) {
-    return geoip.lookup(ip)
+    let response = geoip.lookup(ip)
+    if (!response) {
+      response = {
+        country: ''
+      }
+    }
+
+    return response
   }
 
   async customerOperation (operation, id, info = {}) {
@@ -79,6 +86,7 @@ class Stripe {
 
   async registerCustomer ({ customerId = null, user, ip }) {
     const { country } = await this.getIPDetails(ip)
+
     const customerInfo = {
       name: user.name,
       address: {

--- a/api/service/Stripe.js
+++ b/api/service/Stripe.js
@@ -20,6 +20,7 @@ async function safeStripeOperation (operation, errorMessage) {
 }
 class Stripe {
   async getIPDetails (ip) {
+    logger.warn(`GeoIP lookup failed for IP: ${ip}`)
     let response = geoip.lookup(ip)
     if (!response) {
       response = {


### PR DESCRIPTION
This pull request wraps the `stripeRegister` method in a try-catch block to handle any errors that may occur during the registration process. Additionally, it includes a fix in the `getIPDetails` method to handle cases where the response from the IP lookup is null. These changes improve the error handling and ensure a more robust registration process.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve error handling in the stripeRegister method by wrapping it in a try-catch block and fix the getIPDetails method to handle null responses from IP lookup.

Bug Fixes:
- Fix the getIPDetails method to handle cases where the response from the IP lookup is null by providing a default response.

Enhancements:
- Wrap the stripeRegister method in a try-catch block to improve error handling during the registration process.

<!-- Generated by sourcery-ai[bot]: end summary -->