### PR TITLE
Wrap Stripe register in try-catch and add logging of failed GeoIP lookup

### DIFF
--- a/api/model/Login.js
+++ b/api/model/Login.js
@@ -21,15 +21,15 @@ class Login {
   }
 
   async stripeRegister (user, ip) {
-    const { customerId, country } = await this.stripe.registerCustomer({ customerId: user.customer_id, user, ip })
-    logger.debug(`Stripe customer registered: ${customerId}`)
-    if (!user.customer_id || user.country !== country) {
-      try {
+    try {
+      const { customerId, country } = await this.stripe.registerCustomer({ customerId: user.customer_id, user, ip })
+      logger.debug(`Stripe customer registered: ${customerId}`)
+      if (!user.customer_id || user.country !== country) {
         await this.gql.request(
           REGISTER_CUSTOMER_ID, { id: user.id, customerId, country })
-      } catch (e) {
-        logger.error(`Error registering customer: ${e.message}`)
       }
+    } catch (e) {
+      logger.error(`Error registering customer: ${e.message}`)
     }
   }
 

--- a/api/service/Stripe.js
+++ b/api/service/Stripe.js
@@ -20,7 +20,15 @@ async function safeStripeOperation (operation, errorMessage) {
 }
 class Stripe {
   async getIPDetails (ip) {
-    return geoip.lookup(ip)
+    logger.warn(`GeoIP lookup failed for IP: ${ip}`)
+    let response = geoip.lookup(ip)
+    if (!response) {
+      response = {
+        country: ''
+      }
+    }
+
+    return response
   }
 
   async customerOperation (operation, id, info = {}) {
@@ -79,6 +87,7 @@ class Stripe {
 
   async registerCustomer ({ customerId = null, user, ip }) {
     const { country } = await this.getIPDetails(ip)
+
     const customerInfo = {
       name: user.name,
       address: {

--- a/api/service/Stripe.js
+++ b/api/service/Stripe.js
@@ -20,9 +20,9 @@ async function safeStripeOperation (operation, errorMessage) {
 }
 class Stripe {
   async getIPDetails (ip) {
-    logger.warn(`GeoIP lookup failed for IP: ${ip}`)
     let response = geoip.lookup(ip)
     if (!response) {
+      logger.warn(`GeoIP lookup failed for IP: ${ip}`)
       response = {
         country: ''
       }


### PR DESCRIPTION
This pull request includes two commits. The first commit wraps the Stripe register function in a try-catch block to handle any errors that may occur during the registration process. The second commit adds logging for failed GeoIP lookups, providing visibility into any issues with IP address lookup. These changes improve the error handling and logging capabilities of the code.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve error handling and logging by wrapping the Stripe register function in a try-catch block and adding logging for failed GeoIP lookups.

Bug Fixes:
- Wrap the Stripe register function in a try-catch block to handle errors during the registration process.

Enhancements:
- Add logging for failed GeoIP lookups to provide visibility into IP address lookup issues.

<!-- Generated by sourcery-ai[bot]: end summary -->