### PR TITLE
Add country tax validation and calculation in Payments class

### DIFF
--- a/api/controller/payments.js
+++ b/api/controller/payments.js
@@ -8,7 +8,7 @@ class PaymentController {
   async stripeWebhook (req, res) {
     const sig = req.headers['stripe-signature']
     const response = await this.paymentsModel.verifyStripeWebhook(sig, req.rawBody)
-    req.log.info(`stripe verify response:  ${JSON.stringify(response)}`)
+    req.log.debug(`stripe verify response:  ${JSON.stringify(response)}`)
 
     return response
   }

--- a/api/model/Payments.js
+++ b/api/model/Payments.js
@@ -1,6 +1,8 @@
 const { BadRequest, Conflict, InternalServerError } = require('http-errors')
 const { logger } = require('../service')
 const { TRANSACTION_TYPES } = require('../constants/payments')
+const { eeaMember } = require('is-european')
+
 const {
   GET_COURSE_BY_ID,
   CREATE_PAYMENT_INTENT,
@@ -143,6 +145,17 @@ class Payments {
     }
 
     return country !== userCountry ? [false, country] : [customerId]
+  }
+
+  /**
+   * Asserts the validation of country tax.
+   *
+   * @param {Object} options - The options object.
+   * @param {string} options.country - The country to validate.
+   * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the country tax is valid.
+   */
+  async assertCountryTaxValidation ({ country }) {
+    return eeaMember(country)
   }
 
   async createStripeTaxCalculation ({

--- a/api/model/Payments.js
+++ b/api/model/Payments.js
@@ -156,13 +156,13 @@ class Payments {
   }
 
   /**
-   * Asserts the validation of country tax.
+   * Validates the country tax for a payment.
    *
    * @param {Object} options - The options object.
    * @param {string} options.country - The country to validate.
-   * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating if the country tax is valid.
+   * @throws {BadRequest} If the country is not part of the EEA.
    */
-  async assertCountryTaxValidation ({ country }) {
+  assertCountryTaxValidation ({ country }) {
     if (!eeaMember(country)) {
       throw new BadRequest(`Country ${country} is not part of the EEA`)
     }

--- a/api/model/Payments.js
+++ b/api/model/Payments.js
@@ -158,6 +158,18 @@ class Payments {
     return eeaMember(country)
   }
 
+  /**
+   * Creates a Stripe tax calculation for a payment.
+   *
+   * @param {Object} options - The options for creating the tax calculation.
+   * @param {string} options.customerId - The ID of the customer.
+   * @param {string} options.country - The selected country by the customer.
+   * @param {number} options.cost - The cost of the payment.
+   * @param {string} options.sku - The SKU of the payment.
+   * @param {string} options.userCountry - The country of the user. (our db)
+   * @returns {Object} - The tax calculation result.
+   * @throws {Error} - If there is an error calculating the tax.
+   */
   async createStripeTaxCalculation ({
     customerId,
     country,

--- a/api/package.json
+++ b/api/package.json
@@ -46,6 +46,7 @@
     "graphql-request": "^6.1.0",
     "handlebars": "^4.7.8",
     "http-errors": "^2.0.0",
+    "is-european": "^1.0.8",
     "it-all": "^3.0.3",
     "jsonwebtoken": "^9.0.1",
     "puppeteer": "^21.3.6",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -3603,6 +3603,13 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-european@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/is-european/-/is-european-1.0.8.tgz#08c7455d227c33fbb8e439fafc25cc456360b057"
+  integrity sha512-eKl5xl1hdE/FSVpk7l92wArxcd+/oJHnbDZmUjQyKipo7d40JxKV2VfpufRhlPWwxLTtfeOrCO/nyFyL8amRFQ==
+  dependencies:
+    iso-3166 "~3.1.0"
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3761,6 +3768,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+iso-3166@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/iso-3166/-/iso-3166-3.1.0.tgz#0581492579d9513fa87381acbc6ad736ad2d9f16"
+  integrity sha512-evfmpa/xssMZ00Av6CyLXeqy8jfWC+eNrEYnqLNk6GspAPaXewQD1zoVyAy26sj1nTUhu+HInevnk6vI+Tufig==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add country tax validation and calculation to the Payments class, including a method to assert EEA membership for tax purposes. Modify logging level in the payments controller for Stripe webhook verification.

New Features:
- Introduce country tax validation and calculation in the Payments class, ensuring tax is calculated only for users from the same country as the course and if the country is part of the EEA.

Enhancements:
- Add a method to assert the validation of country tax, throwing an error if the country is not part of the EEA.

<!-- Generated by sourcery-ai[bot]: end summary -->