### PR TITLE
Erick/feat/ilithya_requests (#484)

### DIFF
--- a/hasura/migrations/academy_db/1728420197945_alter_table_public_modules_add_column_is_countable/down.sql
+++ b/hasura/migrations/academy_db/1728420197945_alter_table_public_modules_add_column_is_countable/down.sql
@@ -1,0 +1,3 @@
+-- Down Migration: Revert by dropping the is_countable column
+ALTER TABLE "public"."modules" 
+DROP COLUMN "is_countable";

--- a/hasura/migrations/academy_db/1728420197945_alter_table_public_modules_add_column_is_countable/up.sql
+++ b/hasura/migrations/academy_db/1728420197945_alter_table_public_modules_add_column_is_countable/up.sql
@@ -1,0 +1,8 @@
+-- Up Migration: Add the is_countable column and update the necessary records
+ALTER TABLE "public"."modules" 
+ADD COLUMN "is_countable" BOOLEAN NOT NULL DEFAULT 'true';
+
+-- Update the specific modules to be not countable
+UPDATE "public"."modules"
+SET "is_countable" = false
+WHERE "id" IN ('a6a98f91-6bf6-4795-98b0-33822993a960', 'dafb0e22-8aac-4098-aab4-100beafef5fa');

--- a/hasura/migrations/academy_db/1728424074974_alter_table_public_modules_add_column_subtitle/down.sql
+++ b/hasura/migrations/academy_db/1728424074974_alter_table_public_modules_add_column_subtitle/down.sql
@@ -1,0 +1,3 @@
+-- Drop the subtitle column
+ALTER TABLE "public"."modules" 
+DROP COLUMN "subtitle";

--- a/hasura/migrations/academy_db/1728424074974_alter_table_public_modules_add_column_subtitle/up.sql
+++ b/hasura/migrations/academy_db/1728424074974_alter_table_public_modules_add_column_subtitle/up.sql
@@ -1,0 +1,24 @@
+alter table "public"."modules" add column "subtitle" text
+ null;
+
+
+-- Update subtitles for countable modules using IDs (storing only "Module #")
+UPDATE "public"."modules"
+SET "subtitle" = 'Module 1'
+WHERE "id" = '86bc521b-42de-476f-a738-cf7dcb4bcb6d';
+
+UPDATE "public"."modules"
+SET "subtitle" = 'Module 2'
+WHERE "id" = '28e8a011-ad3b-4f2f-8687-ce17485c434d';
+
+UPDATE "public"."modules"
+SET "subtitle" = 'Module 3'
+WHERE "id" = 'ba883c86-a829-4df4-832a-acd10f0adf97';
+
+UPDATE "public"."modules"
+SET "subtitle" = 'Module 4'
+WHERE "id" = '8efe00aa-57ad-4498-bc39-bb86c1743f42';
+
+UPDATE "public"."modules"
+SET "subtitle" = 'Module 5'
+WHERE "id" = '466b727c-f5fa-402c-a9e6-e34317c54fcd';

--- a/hasura/migrations/academy_db/1728427087093_ilithya_changes/down.sql
+++ b/hasura/migrations/academy_db/1728427087093_ilithya_changes/down.sql
@@ -1,0 +1,110 @@
+-- Welcome Module
+UPDATE chapters
+SET title = 'Course Introduction'
+WHERE id = '3dbd7594-ecd1-487d-a98d-6a915049b455';
+
+-- Basics Module
+UPDATE chapters
+SET title = 'The Shaders'
+WHERE id = 'b127c9e1-698c-4cd7-a534-c41c87b1893b';
+
+UPDATE chapters
+SET title = 'Pixel Shaders'
+WHERE id = '1631e746-0efc-4e49-becb-6a0c6c44a749';
+
+UPDATE chapters
+SET title = 'GLSL Syntax'
+WHERE id = 'e7387a97-af99-4976-87b9-6510235c89d8';
+
+UPDATE chapters
+SET title = 'UV Space'
+WHERE id = '9c294d3f-4df5-4532-bb81-ce6621b8dc13';
+
+UPDATE chapters
+SET title = 'UV Centering & Aspect Ratio'
+WHERE id = '5c0eb529-985d-44de-b83d-78360313efae';
+
+-- Color Module
+UPDATE chapters
+SET title = 'RGB Color Model'
+WHERE id = 'ea905e11-a99c-4148-8705-338779763f35';
+
+UPDATE chapters
+SET title = 'Luminosity Gradients'
+WHERE id = 'e22d8840-239e-42c9-b6f7-dbc76a656b1a';
+
+UPDATE chapters
+SET title = 'Saturation Continuum Gradients'
+WHERE id = '40cbea88-12fd-4e7f-a374-6cf8440d9603';
+
+-- Geometries Module
+UPDATE chapters
+SET title = 'Bending Space'
+WHERE id = 'e982fbb2-7c2b-48a8-969b-7d7fbcc313f4';
+
+UPDATE chapters
+SET title = 'Circle Pt 1'
+WHERE id = '0e6008a4-5402-41ad-bec4-7d4237e46400';
+
+UPDATE chapters
+SET title = 'Circle Pt 2'
+WHERE id = '974053b1-077c-4fca-bc2c-131c9bc5fcb5';
+
+UPDATE chapters
+SET title = 'Circle Pt 3'
+WHERE id = '3c0d4bf4-bd5d-4bb6-bf58-730e0d242ce6';
+
+UPDATE chapters
+SET title = 'Square Pt 1'
+WHERE id = 'e7a4c97a-619e-4cda-9d9f-fb080a6bd23b';
+
+UPDATE chapters
+SET title = 'Square Pt 2'
+WHERE id = 'b57e8b32-780f-47e5-9a9d-3a12ee6a7fd6';
+
+UPDATE chapters
+SET title = 'Triangle'
+WHERE id = '899ecea6-9c2d-4779-9677-81057dafbb72';
+
+UPDATE chapters
+SET title = 'Ring'
+WHERE id = '04847452-264b-4bed-be37-ac2ce8b7c316';
+
+-- Patterns Module
+UPDATE chapters
+SET title = 'Repeating Space'
+WHERE id = '5fc650d0-8c74-4454-90fd-bf169dd740f5';
+
+UPDATE chapters
+SET title = 'Linear Repetition Pt 1'
+WHERE id = '4651437f-2d0a-4b0c-9fb3-0cbcf517775d';
+
+UPDATE chapters
+SET title = 'Linear Repetition Pt 2'
+WHERE id = '83f27b85-5e10-4429-a9fc-6e04c8b9a6d2';
+
+UPDATE chapters
+SET title = 'Grid Repetition'
+WHERE id = '6156514a-9bb8-4b88-bbe7-117641d5ae28';
+
+UPDATE chapters
+SET title = 'Mix Repetition'
+WHERE id = '1c3463e5-8774-46b2-9b41-8b6c85fb2650';
+
+-- Motion Module
+UPDATE chapters
+SET title = 'Time Clock'
+WHERE id = '22560dcf-970c-4e46-8a8c-c8cdc4dcb5ff';
+
+UPDATE chapters
+SET title = 'Trigonometry Pt 1'
+WHERE id = 'c33a7b2f-e979-4247-888a-da13f03a3b06';
+
+UPDATE chapters
+SET title = 'Trigonometry Pt 2'
+WHERE id = 'cd1f2792-0139-4e4b-b72d-0c1f0b6bcb43';
+
+-- Goodbye Module
+UPDATE chapters
+SET title = 'Course Ending'
+WHERE id = 'b2b58372-1a97-42b5-ac2e-c04a52fe841a';

--- a/hasura/migrations/academy_db/1728427087093_ilithya_changes/up.sql
+++ b/hasura/migrations/academy_db/1728427087093_ilithya_changes/up.sql
@@ -1,0 +1,110 @@
+-- Welcome Module
+UPDATE chapters
+SET title = 'Chapter 1: Course Introduction'
+WHERE id = '3dbd7594-ecd1-487d-a98d-6a915049b455';
+
+-- Basics Module
+UPDATE chapters
+SET title = 'Chapter 1: The Shaders'
+WHERE id = 'b127c9e1-698c-4cd7-a534-c41c87b1893b';
+
+UPDATE chapters
+SET title = 'Chapter 2: Pixel Shaders'
+WHERE id = '1631e746-0efc-4e49-becb-6a0c6c44a749';
+
+UPDATE chapters
+SET title = 'Chapter 3: GLSL Syntax'
+WHERE id = 'e7387a97-af99-4976-87b9-6510235c89d8';
+
+UPDATE chapters
+SET title = 'Chapter 4: UV Space'
+WHERE id = '9c294d3f-4df5-4532-bb81-ce6621b8dc13';
+
+UPDATE chapters
+SET title = 'Chapter 5: UV Centering & Aspect Ratio'
+WHERE id = '5c0eb529-985d-44de-b83d-78360313efae';
+
+-- Color Module
+UPDATE chapters
+SET title = 'Chapter 1: RGB Color Model'
+WHERE id = 'ea905e11-a99c-4148-8705-338779763f35';
+
+UPDATE chapters
+SET title = 'Chapter 2: Luminosity Gradients'
+WHERE id = 'e22d8840-239e-42c9-b6f7-dbc76a656b1a';
+
+UPDATE chapters
+SET title = 'Chapter 3: Saturation Continuum Gradients'
+WHERE id = '40cbea88-12fd-4e7f-a374-6cf8440d9603';
+
+-- Geometries Module
+UPDATE chapters
+SET title = 'Chapter 1: Bending Space'
+WHERE id = 'e982fbb2-7c2b-48a8-969b-7d7fbcc313f4';
+
+UPDATE chapters
+SET title = 'Chapter 2: Circle Pt 1'
+WHERE id = '0e6008a4-5402-41ad-bec4-7d4237e46400';
+
+UPDATE chapters
+SET title = 'Chapter 3: Circle Pt 2'
+WHERE id = '974053b1-077c-4fca-bc2c-131c9bc5fcb5';
+
+UPDATE chapters
+SET title = 'Chapter 4: Circle Pt 3'
+WHERE id = '3c0d4bf4-bd5d-4bb6-bf58-730e0d242ce6';
+
+UPDATE chapters
+SET title = 'Chapter 5: Square Pt 1'
+WHERE id = 'e7a4c97a-619e-4cda-9d9f-fb080a6bd23b';
+
+UPDATE chapters
+SET title = 'Chapter 6: Square Pt 2'
+WHERE id = 'b57e8b32-780f-47e5-9a9d-3a12ee6a7fd6';
+
+UPDATE chapters
+SET title = 'Chapter 7: Triangle'
+WHERE id = '899ecea6-9c2d-4779-9677-81057dafbb72';
+
+UPDATE chapters
+SET title = 'Chapter 8: Ring'
+WHERE id = '04847452-264b-4bed-be37-ac2ce8b7c316';
+
+-- Patterns Module
+UPDATE chapters
+SET title = 'Chapter 1: Repeating Space'
+WHERE id = '5fc650d0-8c74-4454-90fd-bf169dd740f5';
+
+UPDATE chapters
+SET title = 'Chapter 2: Linear Repetition Pt 1'
+WHERE id = '4651437f-2d0a-4b0c-9fb3-0cbcf517775d';
+
+UPDATE chapters
+SET title = 'Chapter 3: Linear Repetition Pt 2'
+WHERE id = '83f27b85-5e10-4429-a9fc-6e04c8b9a6d2';
+
+UPDATE chapters
+SET title = 'Chapter 4: Grid Repetition'
+WHERE id = '6156514a-9bb8-4b88-bbe7-117641d5ae28';
+
+UPDATE chapters
+SET title = 'Chapter 5: Mix Repetition'
+WHERE id = '1c3463e5-8774-46b2-9b41-8b6c85fb2650';
+
+-- Motion Module
+UPDATE chapters
+SET title = 'Chapter 1: Time Clock'
+WHERE id = '22560dcf-970c-4e46-8a8c-c8cdc4dcb5ff';
+
+UPDATE chapters
+SET title = 'Chapter 2: Trigonometry Pt 1'
+WHERE id = 'c33a7b2f-e979-4247-888a-da13f03a3b06';
+
+UPDATE chapters
+SET title = 'Chapter 3: Trigonometry Pt 2'
+WHERE id = 'cd1f2792-0139-4e4b-b72d-0c1f0b6bcb43';
+
+-- Goodbye Module
+UPDATE chapters
+SET title = 'Chapter 1: Course Ending'
+WHERE id = 'b2b58372-1a97-42b5-ac2e-c04a52fe841a';

--- a/ui/components/accordion/courseCurriculum.vue
+++ b/ui/components/accordion/courseCurriculum.vue
@@ -12,6 +12,10 @@ export default {
     chapters: {
       type: Array,
       required: true
+    },
+    subtitle: {
+      type: String,
+      required: true
     }
   },
   data () {
@@ -60,7 +64,7 @@ export default {
             <Icon icon="material-symbols-light:keyboard-arrow-down-rounded" width="1.5rem" />
           </div>
         </div>
-        <span class="tw-text-gray-500 tw-text-sm">Chapters: {{ chapters.length }}</span>
+        <span class="tw-text-gray-500 tw-text-sm">{{ subtitle }}</span>
       </div>
 
       <transition

--- a/ui/pages/buyCourse/_courseId.vue
+++ b/ui/pages/buyCourse/_courseId.vue
@@ -3,11 +3,7 @@
     <PxModal ref="modalInstance" />
     <b-container style="max-width: 1240px; margin-top:2rem; margin-bottom: 4rem;">
       <b-row v-if="!$apollo.loading" class="mt-md-3">
-        <b-col
-          order="2"
-          order-lg="1"
-          lg="8"
-        >
+        <b-col order="2" order-lg="1" lg="8">
           <div class="course-info">
             <PxPlayer
               :video-id="courses_by_pk.thumbnail_video"
@@ -24,12 +20,12 @@
             <div v-if="courses_by_pk?.recommendations.length" class="tw-mt-8">
               <h5>Recommendations</h5>
               <div class="tw-relative">
-                <swiper
-                  :space-between="16"
-                  :loop="false"
-                  :breakpoints="breakpoints"
-                >
-                  <swiper-slide v-for="(recommendation, index) in courses_by_pk?.recommendations" :key="index" class="tw-my-6 tw-px-2">
+                <swiper :space-between="16" :loop="false" :breakpoints="breakpoints">
+                  <swiper-slide
+                    v-for="(recommendation, index) in courses_by_pk?.recommendations"
+                    :key="index"
+                    class="tw-my-6 tw-px-2"
+                  >
                     <course-recommendation
                       :quote="recommendation.quote"
                       :name="recommendation.name"
@@ -41,7 +37,9 @@
                   </swiper-slide>
                 </swiper>
 
-                <div class="tw-pointer-events-none tw-absolute tw-right-0 tw-top-0 tw-h-full tw-w-16 tw-bg-gradient-to-l tw-from-white tw-to-transparent tw-z-10" />
+                <div
+                  class="tw-pointer-events-none tw-absolute tw-right-0 tw-top-0 tw-h-full tw-w-16 tw-bg-gradient-to-l tw-from-white tw-to-transparent tw-z-10"
+                />
               </div>
             </div>
 
@@ -49,10 +47,7 @@
               You will learn
             </h5>
 
-            <div
-              v-for="itemModule in courses_by_pk.modules"
-              :key="itemModule.id"
-            >
+            <div v-for="itemModule in courses_by_pk.modules" :key="itemModule.id">
               <div v-if="itemModule.you_will_learn" class="d-flex  rounded  mb-2">
                 <div style="margin-right:0.5rem">
                   <Icon icon="material-symbols:check-circle-outline-rounded" color="#00c851" width="1.25rem" />
@@ -72,48 +67,51 @@
               <p v-else>
                 {{ shortDescription }}
               </p>
-              <span v-if="isLargeDescription" style="cursor: pointer; font-weight: 600; font-size: small;" @click="toggleDescription">{{ readDescriptionText }}</span>
+              <span
+                v-if="isLargeDescription"
+                style="cursor: pointer; font-weight: 600; font-size: small;"
+                @click="toggleDescription"
+              >{{ readDescriptionText }}</span>
             </div>
 
             <h5 class="mb-3 mt-4">
               Course curriculum
             </h5>
 
-            <accordion-courseCurriculum v-for="(itemModule, moduleIndex) in courses_by_pk.modules" :key="moduleIndex" :title="itemModule.title" :module-id="moduleIndex" :chapters="itemModule.chapters" />
+            <accordion-course-curriculum
+              v-for="(itemModule, moduleIndex) in courses_by_pk.modules"
+              :key="moduleIndex"
+              :title="itemModule.title"
+              :subtitle="itemModule.subtitle"
+              :module-id="moduleIndex"
+              :chapters="itemModule.chapters"
+            />
           </div>
         </b-col>
 
-        <b-col
-          order="1"
-          order-lg="2"
-          lg="4"
-          class="mb-3"
-        >
-          <PxPlayer
-            :video-id="courses_by_pk.thumbnail_video"
-            chapter-id=""
-            width="100%"
-            class="d-lg-none"
-          />
+        <b-col order="1" order-lg="2" lg="4" class="mb-3">
+          <PxPlayer :video-id="courses_by_pk.thumbnail_video" chapter-id="" width="100%" class="d-lg-none" />
           <div class="d-flex flex-column p-3 shadow-sm rounded " style="gap:0.5rem; position:sticky; top: 77px;">
-            <accordion-course-instructor :pfp="courses_by_pk.teacher.pfp" :name="courses_by_pk.teacher.name" :description="courses_by_pk.teacher.description" />
+            <accordion-course-instructor
+              :pfp="courses_by_pk.teacher.pfp"
+              :name="courses_by_pk.teacher.name"
+              :description="courses_by_pk.teacher.description"
+            />
             <div v-if="!userHasCourse || !$auth.loggedIn" class="d-flex flex-column" style="gap:0.5rem">
               <div class="border rounded p-2">
                 <div class="tw-flex tw-items-center tw-gap-2">
                   <h2 class="m-0 font-weight-bold" style="color:#00b9cd">
                     ${{ courses_by_pk.discount_price || courses_by_pk.price }}
                   </h2>
-                  <h6
-                    v-if="courses_by_pk.discount_price"
-                    class="m-0  tw-line-through tw-text-gray-500"
-                  >
+                  <h6 v-if="courses_by_pk.discount_price" class="m-0  tw-line-through tw-text-gray-500">
                     ${{ courses_by_pk.price }}
                   </h6>
                 </div>
                 <p class="m-0">
                   Access course
                 </p>
-                <span v-if="courses_by_pk.discount_price" class="tw-text-green-500 tw-text-xs">Launch Discount (You save {{ 100 - Math.ceil(courses_by_pk.discount_price * 100 / courses_by_pk.price) }}%!)</span>
+                <span v-if="courses_by_pk.discount_price" class="tw-text-green-500 tw-text-xs">Launch Discount (You save
+                  {{ 100 - Math.ceil(courses_by_pk.discount_price * 100 / courses_by_pk.price) }}%!)</span>
               </div>
               <div v-if="isAccessible">
                 <button-px-primary prefix-icon="credit-card" text="Credit card" width="tw-w-full" @click="openModal" />
@@ -138,14 +136,9 @@
                 <h2>
                   Payment details
                 </h2>
-                <span
-                  style="cursor: pointer"
-                  @click="close()"
-                ><Icon
-                  width="32"
-                  color="#888"
-                  icon="material-symbols:close"
-                /></span>
+                <span style="cursor: pointer" @click="close()">
+                  <Icon width="32" color="#888" icon="material-symbols:close" />
+                </span>
               </template>
               <div>
                 <!-- this line makes the discount_price have priority over the general price -->
@@ -159,27 +152,33 @@
             <div style="width:100%; margin:1rem 0rem; border-bottom:1px solid #6c757d3b" />
             <div class="d-flex-column">
               <div class="d-flex align-items-center mb-2">
-                <Icon icon="material-symbols:alarm-outline" class="mr-2" /><p class="small m-0">
-                  Approx. duration  {{ formattedDuration }}
+                <Icon icon="material-symbols:alarm-outline" class="mr-2" />
+                <p class="small m-0">
+                  Approx. duration {{ formattedDuration }}
                 </p>
               </div>
               <div class="d-flex align-items-center mb-2">
-                <Icon icon="material-symbols:signal-cellular-alt" class="mr-2" /><p class="small m-0">
+                <Icon icon="material-symbols:signal-cellular-alt" class="mr-2" />
+                <p class="small m-0">
                   {{ courses_by_pk.level }} level
                 </p>
               </div>
               <div class="d-flex align-items-center mb-2">
-                <Icon
-                  icon="material-symbols:language"
-
-                  class="mr-2"
-                /><p class="small m-0">
+                <Icon icon="material-symbols:language" class="mr-2" />
+                <p class="small m-0">
+                  {{ courses_by_pk?.modules_aggregate?.aggregate?.count || courses_by_pk?.modules?.length }} modules
+                </p>
+              </div>
+              <div class="d-flex align-items-center mb-2">
+                <Icon icon="material-symbols:language" class="mr-2" />
+                <p class="small m-0">
                   100% Online
                 </p>
               </div>
 
               <div class="d-flex align-items-center mb-2">
-                <Icon icon="material-symbols:verified-outline" class="mr-2" /><p class="small m-0">
+                <Icon icon="material-symbols:verified-outline" class="mr-2" />
+                <p class="small m-0">
                   Certificate
                 </p>
               </div>
@@ -240,6 +239,7 @@ export default {
             release_date
             modules (order_by: {created_at: asc}) {
               title
+              subtitle
               id
               you_will_learn_title
               you_will_learn
@@ -251,6 +251,11 @@ export default {
                 aggregate {
                   count(columns: answer_id)
                 }
+              }
+            }
+            modules_aggregate(where: {is_countable: {_eq: true}}) {
+              aggregate {
+                count(columns: is_countable)
               }
             }
             teacher {


### PR DESCRIPTION
* Add is_countable column to modules table and update necessary records

Refactor the `modules` table in the database by adding a new column `is_countable` with a default value of `true`. Also, update specific modules to be not countable.

* Refactor module count display in buyCourse page

* Refactor module count display in buyCourse page

* feat: add subtitle prop to courseCurriculum component

* feat: Add subtitles to countable modules in public.modules table

This commit adds a new column "subtitle" to the "public.modules" table in the database. The "subtitle" column is used to store the subtitle for countable modules. The commit also updates the subtitles for specific countable modules using their IDs.

Co-authored-by: [Author Name]

* update chapter names

* update chapter names

## Summary by Sourcery

Add 'is_countable' and 'subtitle' columns to the 'modules' table to enhance module management and display. Refactor the buyCourse page to utilize these new attributes, and update chapter names for clarity.

New Features:
- Add a new 'is_countable' column to the 'modules' table in the database to indicate whether a module should be counted, with a default value of true.
- Introduce a 'subtitle' column to the 'public.modules' table to store subtitles for countable modules.

Enhancements:
- Refactor the module count display on the buyCourse page to accommodate the new 'is_countable' attribute.
- Add a 'subtitle' prop to the courseCurriculum component to display module subtitles.

Chores:
- Update chapter names in the database to include more descriptive titles.