### PR TITLE
Refactor error handling in getContractStorageFromOperationHash function

### DIFF
--- a/api/model/Documents.js
+++ b/api/model/Documents.js
@@ -59,7 +59,7 @@ class Documents {
 
     try {
       const { data } = await axios.request(options)
-
+      logger.debug(`Response for ${opHash} on attempt ${intent}: ${JSON.stringify(data)}`)
       if (data && data[0] && data[0].storage) {
         return data[0].storage // Return storage data immediately on success
       } else {

--- a/api/model/Documents.js
+++ b/api/model/Documents.js
@@ -44,20 +44,36 @@ class Documents {
     }
   }
 
-  async getSoulBoundTokenIdFromOpHash (opHash) {
-    const axios = require('axios').default
-    // ${TZKT_ENDPOINT}/v1/operations/${opHash}
+  async getContractStorageFromOperationHash (opHash, intent = 0) {
+    if (intent > 5) {
+      logger.error(`Error while getting information about ${opHash}`)
+      return null
+    }
 
+    const axios = require('axios').default
     const options = {
       method: 'GET',
       url: `${TZKT_ENDPOINT}/v1/operations/${opHash}`,
       headers: { Accept: '*/*', 'User-Agent': 'Thunder Client (https://www.thunderclient.com)' }
     }
 
-    const { data } = await axios.request(options)
-    if (data.length === 0) throw new BadRequest('No operation found')
-    const { storage } = data[0]
+    try {
+      const { data } = await axios.request(options)
 
+      if (data && data[0] && data[0].storage) {
+        return data[0].storage // Return storage data immediately on success
+      } else {
+        logger.error(`Unexpected response structure for ${opHash} on attempt ${intent}`)
+      }
+    } catch (e) {
+      logger.error(`Error(${intent}) while getting information about ${opHash}: ${e.message}`)
+    }
+
+    return await this.getContractStorageFromOperationHash(opHash, intent + 1)
+  }
+
+  async getSoulBoundTokenIdFromOpHash (opHash) {
+    const storage = await this.getContractStorageFromOperationHash(opHash)
     return storage.last_token_id - 1
   }
 

--- a/api/test/model/documents.test.js
+++ b/api/test/model/documents.test.js
@@ -1,0 +1,75 @@
+const { describe, test, before, after } = require('node:test')
+const assert = require('node:assert')
+const { TezosConstants } = require('../../constants')
+
+const DocumentsModel = require('../../model/Documents.js')
+
+const {
+  GQL,
+  JWT,
+  Email,
+  Documents: Docs,
+  SbtSmartContract
+} = require('../../service')
+
+const email = new Email({ apiKey: process.env.SENDGRID_API_KEY })
+const {
+  GRAPHQL_ENDPOINT,
+  GRAPHQL_SECRET
+} = process.env
+
+const gqlConfig = {
+  endpoint: GRAPHQL_ENDPOINT,
+  secret: GRAPHQL_SECRET
+}
+const gql = new GQL(gqlConfig)
+const jwt = new JWT({})
+const opts = {
+  tokenExpirationTimeMins: 60,
+  refreshTokenExpirationTimeMins: 1440
+}
+const sbtSC = new SbtSmartContract({ contract: TezosConstants.CONTRACT_ADDRESSES.sbt })
+
+describe('Documents model', () => {
+  test('Documents model works standalone', async (t) => {
+    const documentsModel = new DocumentsModel({
+      gql,
+      jwt,
+      email,
+      opts,
+      docs: new Docs(),
+      sbtSC
+    })
+
+    assert.ok(documentsModel)
+  })
+})
+
+describe('Documents model', () => {
+  let documentsModel = null
+
+  before(async () => {
+    documentsModel = new DocumentsModel({
+      gql,
+      jwt,
+      email,
+      opts,
+      docs: new Docs(),
+      sbtSC
+    })
+  })
+
+  test('Documents model works standalone', async (t) => {
+    assert.ok(documentsModel)
+  })
+
+  test('Get contract storage from operation hash', async (t) => {
+    // arrange
+    const opHash = 'op8zy3gWFX8tozmxkZgsPYMrgoTQcD7QLXhaTvUyxKMfdXv61te'
+    // act
+    const contractStorage = await documentsModel.getContractStorageFromOperationHash(opHash)
+
+    // assert
+    assert.ok(contractStorage)
+  })
+})

--- a/api/test/model/documents.test.js
+++ b/api/test/model/documents.test.js
@@ -72,4 +72,14 @@ describe('Documents model', () => {
     // assert
     assert.ok(contractStorage)
   })
+
+  test('Get token id from operation hash', async (t) => {
+    // arrange
+    const opHash = 'op8zy3gWFX8tozmxkZgsPYMrgoTQcD7QLXhaTvUyxKMfdXv61te'
+    // act
+    const tokenId = await documentsModel.getSoulBoundTokenIdFromOpHash(opHash)
+
+    // assert
+    assert.ok(tokenId)
+  })
 })


### PR DESCRIPTION
This pull request refactors the error handling in the `getContractStorageFromOperationHash` function to improve its reliability. It adds a check for the number of attempts made and logs any errors encountered. Additionally, it includes a new feature to get the token ID from an operation hash. The changes ensure that the function returns the storage data immediately on success and retries the request if there are unexpected response structures or errors.

## Summary by Sourcery

Refactor the getContractStorageFromOperationHash function to improve error handling by adding retry logic and logging. Introduce a new feature to retrieve the token ID from an operation hash. Add tests to verify the functionality of these changes.

New Features:
- Add functionality to retrieve token ID from an operation hash.

Enhancements:
- Refactor error handling in getContractStorageFromOperationHash to include retry logic and improved logging.

Tests:
- Add tests for getContractStorageFromOperationHash and getSoulBoundTokenIdFromOpHash functions to ensure correct functionality.