### PR TITLE
Change discount label

### DIFF
--- a/ui/pages/buyCourse/_courseId.vue
+++ b/ui/pages/buyCourse/_courseId.vue
@@ -128,7 +128,7 @@
                 <p class="m-0">
                   Access course
                 </p>
-                <span v-if="courses_by_pk.discount_price" class="tw-text-green-500 tw-text-xs">Christmas Discount 🎁 (You
+                <span v-if="courses_by_pk.discount_price" class="tw-text-green-500 tw-text-xs">Discount (You
                   save
                   {{ 100 - Math.ceil(courses_by_pk.discount_price * 100 / courses_by_pk.price) }}%!)</span>
               </div>


### PR DESCRIPTION
Fixes #497

Change the label for discounts in the `ui/pages/buyCourse/_courseId.vue` file.

* Update the discount label text from "Christmas Discount 🎁" to "Discount" in the span element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Blind-Gallery/BG-Academy/pull/498?shareId=243d09ef-03d3-4e64-aea9-7857c5509ea0).

## Summary by Sourcery

Bug Fixes:
- Change the discount label from "Christmas Discount 🎁" to "Discount".